### PR TITLE
Add support for specifying Less paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wintersmith-less",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Johan Nordberg <its@johan-nordberg.com>",
   "description": "less plugin for wintersmith",
   "license": "MIT",
@@ -12,6 +12,7 @@
   "dependencies": {
     "less": "1.4.x",
     "async": ">= 0.0.1",
-    "coffee-script": ">=1.7"
+    "coffee-script": ">=1.7",
+    "lodash": "~2.4.1"
   }
 }

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -2,6 +2,7 @@ less = require 'less'
 path = require 'path'
 async = require 'async'
 fs = require 'fs'
+_ = require 'lodash'
 
 module.exports = (env, callback) ->
 
@@ -14,9 +15,13 @@ module.exports = (env, callback) ->
 
     getView: ->
       return (env, locals, contents, templates, callback) ->
-        options = env.config.less or {}
+        options = if env.config.less then _.cloneDeep env.config.less else {}
         options.filename = @filepath.relative
-        options.paths = [path.dirname(@filepath.full)]
+        if options.paths
+          options.paths = (path.resolve(loc) for loc in options.paths)
+        else
+          options.paths = []
+        options.paths = _.union options.paths [path.dirname(@filepath.full)]
         # less throws errors all over the place...
         async.waterfall [
           (callback) ->


### PR DESCRIPTION
This would allow users to specify paths for Less to use when resolving `@import` statements. Currently they are ignored and discarded.
