### PR TITLE
Add support for specifying Less paths

### DIFF
--- a/example/templates/index.jade
+++ b/example/templates/index.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang='en')
   head
     meta(charset='utf-8')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "less"
   ],
   "dependencies": {
-    "less": "1.4.x",
+    "less": "~1.7.0",
     "async": ">= 0.0.1",
     "coffee-script": ">=1.7",
     "lodash": "~2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wintersmith-less",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Johan Nordberg <its@johan-nordberg.com>",
   "description": "less plugin for wintersmith",
   "license": "MIT",
@@ -12,6 +12,7 @@
   "dependencies": {
     "less": "1.4.x",
     "async": ">= 0.0.1",
-    "coffee-script": ">=1.7"
+    "coffee-script": ">=1.7",
+    "lodash": "~2.4.1"
   }
 }

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -21,7 +21,7 @@ module.exports = (env, callback) ->
           options.paths = (path.resolve(loc) for loc in options.paths)
         else
           options.paths = []
-        options.paths = _.union options.paths [path.dirname(@filepath.full)]
+        options.paths = _.union options.paths, [path.dirname(@filepath.full)]
         # less throws errors all over the place...
         async.waterfall [
           (callback) ->

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -2,6 +2,7 @@ less = require 'less'
 path = require 'path'
 async = require 'async'
 fs = require 'fs'
+_ = require 'lodash'
 
 module.exports = (env, callback) ->
 
@@ -14,9 +15,13 @@ module.exports = (env, callback) ->
 
     getView: ->
       return (env, locals, contents, templates, callback) ->
-        options = env.config.less or {}
+        options = if env.config.less then _.cloneDeep env.config.less else {}
         options.filename = @filepath.relative
-        options.paths = [path.dirname(@filepath.full)]
+        if options.paths
+          options.paths = (path.resolve(loc) for loc in options.paths)
+        else
+          options.paths = []
+        options.paths = _.union options.paths [path.dirname(@filepath.full)]
         # less throws errors all over the place...
         async.waterfall [
           (callback) ->


### PR DESCRIPTION
This will add the ability to specify Less paths in the `config.json` file. Less uses those paths when resolving `@import` statements.